### PR TITLE
Add a few missing fields to Node and Workspace

### DIFF
--- a/examples/get_tree.rs
+++ b/examples/get_tree.rs
@@ -1,0 +1,13 @@
+use std::io;
+
+use tokio_i3ipc::{reply, I3};
+
+#[tokio::main(basic_scheduler)]
+async fn main() -> io::Result<()> {
+    let mut i3 = I3::connect().await?;
+    // this type can be inferred, here is written explicitly:
+    let tree: reply::Node = i3.get_tree().await?;
+    println!("{:#?}", tree);
+
+    Ok(())
+}

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -16,6 +16,7 @@ pub type Workspaces = Vec<Workspace>;
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Workspace {
+    pub id: usize,
     pub num: usize,
     pub name: String,
     pub visible: bool,
@@ -53,9 +54,12 @@ pub struct Node {
     pub window_rect: Rect,
     pub deco_rect: Rect,
     pub geometry: Rect,
+    pub window: Option<u32>,
     pub window_properties: Option<WindowProperties>,
+    pub window_type: Option<WindowType>,
     pub current_border_width: i32,
     pub urgent: bool,
+    pub marks: Option<Marks>,
     pub focused: bool,
     pub focus: Vec<usize>,
     pub sticky: bool,
@@ -168,6 +172,23 @@ pub enum WindowProperty {
     Class,
     WindowRole,
     TransientFor,
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Copy, Hash, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowType {
+    Normal,
+    Dock,
+    Dialog,
+    Utility,
+    Toolbar,
+    Splash,
+    Menu,
+    DropdownMenu,
+    PopupMenu,
+    Tooltip,
+    Notification,
+    Unknown,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]


### PR DESCRIPTION
I had a chance to try out the `current_border_width` change in 0.9, and it looks like it's working correctly for me. I noticed a few more missing fields, so I went through the current [IPC](https://i3wm.org/docs/ipc.html) documentation and added the ones I managed to find. 

I also added a `get_tree` example, which served as a convenient sanity check to see that these changes were actually working as expected. 

Note that there seems to be a slight discrepancy between the i3 docs and source regarding the `window_type` field.

From the website:

> window_type (string)
> 
> The window type (_NET_WM_WINDOW_TYPE). Possible values are undefined, normal, dialog, utility, toolbar, splash, menu, dropdown_menu, popup_menu, tooltip and notification.

From the i3 source:
```C
    ystr("window_type");
    if (con->window) {
        if (con->window->window_type == A__NET_WM_WINDOW_TYPE_NORMAL) {
            ystr("normal");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DOCK) {
            ystr("dock");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DIALOG) {
            ystr("dialog");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_UTILITY) {
            ystr("utility");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_TOOLBAR) {
            ystr("toolbar");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_SPLASH) {
            ystr("splash");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_MENU) {
            ystr("menu");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DROPDOWN_MENU) {
            ystr("dropdown_menu");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_POPUP_MENU) {
            ystr("popup_menu");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_TOOLTIP) {
            ystr("tooltip");
        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_NOTIFICATION) {
            ystr("notification");
        } else {
            ystr("unknown");
        }
    } else
        y(null);
```
https://github.com/i3/i3/blob/e67407302738fdc79d9ed1970a60cc580ccf34fe/src/ipc.c#L529-L557

I used the string fields from the i3 source when defining `WindowType`.

I didn't bump the version number so you can decide how/when/whether to incorporate these changes. 

BTW, thanks for writing these libraries. They're well written and have been really nice to work with!