### PR TITLE
Fixed incompatability issue with i3 < 4.18.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-i3ipc"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -18,7 +18,7 @@ repository = "https://github.com/leshow/tokio-i3ipc"
 bytes = "0.5"
 serde = "1.0"
 serde_json = "1.0"
-i3ipc-types = { version = "0.10", path = "i3ipc-types", features = ["async-traits"] }
+i3ipc-types = { version = "0.11", path = "i3ipc-types", features = ["async-traits"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 tokio = { version = "0.2.19", features = ["io-std", "io-util", "net", "macros", "stream"] }
 

--- a/async-i3ipc/Cargo.toml
+++ b/async-i3ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-i3ipc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -21,7 +21,7 @@ repository = "https://github.com/leshow/tokio-i3ipc/tree/master/async-i3ipc"
 async-std = { version = "1.6.2", features = ["attributes"] }
 serde = "1.0"
 serde_json = "1.0"
-i3ipc-types = { version = "0.10", path = "../i3ipc-types", features = ["async-std-traits"] }
+i3ipc-types = { version = "0.11", path = "../i3ipc-types", features = ["async-std-traits"] }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/async-i3ipc/src/lib.rs
+++ b/async-i3ipc/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/async-i3ipc/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/async-i3ipc/0.2.0")]
 //! # async-i3ipc
 //!
 //! This crate provides types and functions for working with i3's IPC protocol

--- a/i3-ipc/Cargo.toml
+++ b/i3-ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i3_ipc"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -13,7 +13,7 @@ keywords = ["i3", "ipc", "protocol", "json", "serde"]
 repository = "https://github.com/leshow/tokio-i3ipc/tree/master/i3-ipc"
 
 [dependencies]
-i3ipc-types = { version = "0.10", path = "../i3ipc-types" }
+i3ipc-types = { version = "0.11", path = "../i3ipc-types" }
 serde = "1.0"
 serde_json = "1.0"
 

--- a/i3ipc-types/Cargo.toml
+++ b/i3ipc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i3ipc-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 description = """
 Library containing all the types needed to communicate with i3, along with their serde implementations 

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -16,7 +16,7 @@ pub type Workspaces = Vec<Workspace>;
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Workspace {
-    pub id: usize,
+    pub id: Option<usize>,
     pub num: usize,
     pub name: String,
     pub visible: bool,
@@ -43,6 +43,7 @@ pub struct Output {
 pub struct Node {
     pub id: usize,
     pub name: Option<String>,
+    pub num: Option<String>,
     #[serde(rename = "type")]
     pub node_type: NodeType,
     pub layout: NodeLayout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-i3ipc/0.10.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-i3ipc/0.11.0")]
 //! # tokio-i3ipc
 //!
 //! This crate provides types and functions for working with i3's IPC protocol


### PR DESCRIPTION
Versions of i3 before 4.18 didn't include an `id` field in replies to the `get_workspaces` request, meaning `get_workspaces` requests always fail with a serde error of "missing field `id`". 
This fixes it by copying the value of the `num` field to avoid chainging the API/breaking compatability.