### PR TITLE
Make workspace id default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-i3ipc"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -18,7 +18,7 @@ repository = "https://github.com/leshow/tokio-i3ipc"
 bytes = "0.5"
 serde = "1.0"
 serde_json = "1.0"
-i3ipc-types = { version = "0.10", path = "i3ipc-types", features = ["async-traits"] }
+i3ipc-types = { version = "0.11", path = "i3ipc-types", features = ["async-traits"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 tokio = { version = "0.2.19", features = ["io-std", "io-util", "net", "macros", "stream"] }
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This crate provides types and functions for working with i3's IPC protocol withi
 I expect the most common use case will be to subscribe to some events and listen:
 
 ```rust
-use futures::stream::StreamExt;
 use std::io;
+use tokio::stream::StreamExt;
 use tokio_i3ipc::{
     event::{Event, Subscribe},
     I3,

--- a/async-i3ipc/Cargo.toml
+++ b/async-i3ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-i3ipc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -21,7 +21,7 @@ repository = "https://github.com/leshow/tokio-i3ipc/tree/master/async-i3ipc"
 async-std = { version = "1.6.2", features = ["attributes"] }
 serde = "1.0"
 serde_json = "1.0"
-i3ipc-types = { version = "0.10", path = "../i3ipc-types", features = ["async-std-traits"] }
+i3ipc-types = { version = "0.11", path = "../i3ipc-types", features = ["async-std-traits"] }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/async-i3ipc/src/lib.rs
+++ b/async-i3ipc/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/async-i3ipc/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/async-i3ipc/0.2.0")]
 //! # async-i3ipc
 //!
 //! This crate provides types and functions for working with i3's IPC protocol

--- a/i3-ipc/Cargo.toml
+++ b/i3-ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i3_ipc"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """
@@ -13,7 +13,7 @@ keywords = ["i3", "ipc", "protocol", "json", "serde"]
 repository = "https://github.com/leshow/tokio-i3ipc/tree/master/i3-ipc"
 
 [dependencies]
-i3ipc-types = { version = "0.10", path = "../i3ipc-types" }
+i3ipc-types = { version = "0.11", path = "../i3ipc-types" }
 serde = "1.0"
 serde_json = "1.0"
 

--- a/i3ipc-types/Cargo.toml
+++ b/i3ipc-types/Cargo.toml
@@ -14,9 +14,8 @@ categories = ["api-bindings", "parsing", "command-line-utilities", "gui"]
 repository = "https://github.com/leshow/tokio-i3ipc/tree/master/i3ipc-types"
 
 [dependencies]
-serde = "1.0"
+serde = { version ="1.0", features = ["derive"] }
 serde_repr = "0.1"
-serde_derive = "1.0"
 serde_json = "1.0"
 
 [features]

--- a/i3ipc-types/Cargo.toml
+++ b/i3ipc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i3ipc-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Evan Cameron <cameron.evan@gmail.com>"]
 description = """
 Library containing all the types needed to communicate with i3, along with their serde implementations 

--- a/i3ipc-types/src/event.rs
+++ b/i3ipc-types/src/event.rs
@@ -1,7 +1,7 @@
 //! For subscribing and receiving events, each struct matches a particular
 //! `Subscribe` variant. For instance, subscribing with `Subscribe::Workspace`
 //! will net `Event::Workspace` when workspace events are sent over the ipc.
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::reply;
 

--- a/i3ipc-types/src/lib.rs
+++ b/i3ipc-types/src/lib.rs
@@ -4,10 +4,10 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use std::{env, io, process::Command};
 
-#[cfg(feature = "async-traits")]
+#[cfg(all(feature = "async-traits", not(feature = "async-std-traits")))]
 use tokio::io::{AsyncRead, AsyncWrite};
 
-#[cfg(feature = "async-std-traits")]
+#[cfg(all(feature = "async-std-traits", not(feature = "async-traits")))]
 use async_std::io::{Read as AsyncStdRead, Write as AsyncStdWrite};
 
 pub mod event;

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -16,7 +16,8 @@ pub type Workspaces = Vec<Workspace>;
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Workspace {
-    pub id: Option<usize>,
+    #[serde(default)]
+    pub id: usize,
     pub num: usize,
     pub name: String,
     pub visible: bool,

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -1,5 +1,5 @@
 //! Contains structs for deserializing messages from i3
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use std::collections::HashMap;

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -330,18 +330,29 @@ mod tests {
         let o: Result<Workspace, serde_json::error::Error> = serde_json::from_str(output);
         assert!(o.is_ok());
     }
+
+    #[test]
+    fn test_workspace_no_id() {
+        let output = "{\"num\":2,\"name\":\"2\",\"visible\":false,\"focused\":false,\"rect\":{\"x\":2560,\"y\":29,\"width\":2560,\"height\":1571},\"output\":\"DVI-I-3\",\"urgent\":false}";
+        let o: Result<Workspace, serde_json::error::Error> = serde_json::from_str(output);
+        assert!(o.is_ok());
+        assert_eq!(o.unwrap().id, 0);
+    }
+
     #[test]
     fn test_binding_modes() {
         let output = "[\"resize\",\"default\"]";
         let o: Result<BindingModes, serde_json::error::Error> = serde_json::from_str(output);
         assert!(o.is_ok());
     }
+
     #[test]
     fn test_config() {
         let output = "{\"config\": \"some config data here\"}";
         let o: Result<Config, serde_json::error::Error> = serde_json::from_str(output);
         assert!(o.is_ok());
     }
+
     #[test]
     fn test_tree() {
         use std::fs;
@@ -349,6 +360,7 @@ mod tests {
         let o: Result<Node, serde_json::error::Error> = serde_json::from_str(&output);
         assert!(o.is_ok());
     }
+
     #[test]
     fn test_other_tree() {
         use std::fs;
@@ -356,6 +368,7 @@ mod tests {
         let o: Result<Node, serde_json::error::Error> = serde_json::from_str(&output);
         assert!(o.is_ok());
     }
+
     #[test]
     fn test_last_tree() {
         use std::fs;
@@ -363,6 +376,7 @@ mod tests {
         let o: Result<Node, serde_json::error::Error> = serde_json::from_str(&output);
         assert!(o.is_ok());
     }
+
     #[test]
     fn test_version() {
         use std::fs;

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -16,7 +16,7 @@ pub type Workspaces = Vec<Workspace>;
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Workspace {
-    pub id: usize,
+    pub id: Option<usize>,
     pub num: usize,
     pub name: String,
     pub visible: bool,
@@ -43,6 +43,7 @@ pub struct Output {
 pub struct Node {
     pub id: usize,
     pub name: Option<String>,
+    pub num: Option<String>,
     #[serde(rename = "type")]
     pub node_type: NodeType,
     pub layout: NodeLayout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-i3ipc/0.10.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-i3ipc/0.11.0")]
 //! # tokio-i3ipc
 //!
 //! This crate provides types and functions for working with i3's IPC protocol


### PR DESCRIPTION
- Fixed incompatability issue with i3 < 4.18.
- Fix version numbers in doc-roots.
- fix: remove serde_derive
- fix: Update README
- Use default instead of Option for id
- Add test for no id


I accidentally merged the incomplete other branch (still getting used to github cli)

This has the fix + a test
