### PR TITLE
Basic sway support

### DIFF
--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -22,6 +22,7 @@ pub struct Workspace {
     pub name: String,
     pub visible: bool,
     pub focused: bool,
+    pub focus: Vec<usize>,
     pub urgent: bool,
     pub rect: Rect,
     pub output: String,
@@ -69,6 +70,7 @@ pub struct Node {
     pub floating_nodes: Vec<Node>,
     pub fullscreen_mode: FullscreenMode,
     pub nodes: Vec<Node>,
+    pub app_id: Option<String>,
 }
 
 impl PartialEq for Node {
@@ -86,6 +88,7 @@ pub struct WindowProperties {
     class: Option<String>,
     window_role: Option<String>,
     transient_for: Option<u64>,
+    window_type: Option<String>,
 }
 
 impl<'de> serde::Deserialize<'de> for WindowProperties {
@@ -138,6 +141,10 @@ impl<'de> serde::Deserialize<'de> for WindowProperties {
             .0
             .get_mut(&WindowProperty::TransientFor)
             .and_then(|x| x.take().map(|x| x.unwrap_num()));
+        let window_type = input
+            .0
+            .get_mut(&WindowProperty::WindowType)
+            .and_then(|x| x.take().map(|x| x.unwrap_str()));
 
         Ok(WindowProperties {
             title,
@@ -145,6 +152,7 @@ impl<'de> serde::Deserialize<'de> for WindowProperties {
             class,
             window_role,
             transient_for,
+            window_type,
         })
     }
 }
@@ -174,6 +182,7 @@ pub enum WindowProperty {
     Class,
     WindowRole,
     TransientFor,
+    WindowType,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Copy, Hash, Debug)]
@@ -217,6 +226,7 @@ pub enum NodeBorder {
     Normal,
     None,
     Pixel,
+    CSD,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Debug, Clone, Copy)]
@@ -228,6 +238,7 @@ pub enum NodeLayout {
     Tabbed,
     Dockarea,
     Output,
+    None,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Debug, Clone, Copy)]

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -83,12 +83,12 @@ impl Eq for Node {}
 
 #[derive(Eq, Serialize, PartialEq, Clone, Debug)]
 pub struct WindowProperties {
-    title: Option<String>,
-    instance: Option<String>,
-    class: Option<String>,
-    window_role: Option<String>,
-    transient_for: Option<u64>,
-    window_type: Option<String>,
+    pub title: Option<String>,
+    pub instance: Option<String>,
+    pub class: Option<String>,
+    pub window_role: Option<String>,
+    pub transient_for: Option<u64>,
+    pub window_type: Option<String>,
 }
 
 impl<'de> serde::Deserialize<'de> for WindowProperties {


### PR DESCRIPTION
Sway is generally i3-compatible, but has a few more options on some of the enums that cause runtime errors when decoding. This PR adds the minimal fields needed to deserialise the node tree on my local setup, plus `app_id` (which is essentially the Wayland replacement for the `class` window property). `sway-ipc(7)` indicates that there are a handful more fields that could be added, but I haven't tried to implement them for now.

I also ran into `WindowProperties` having private (and therefore inaccessible) fields: I've put the code to make those fields public in this PR (since the Sway compatibility work has to add `window_type` to `WindowProperties`), but I can separate them if you'd prefer. (They're in different commits, at least.)