### PR TITLE
Make i3ipc-types features additive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,2 @@
 [workspace]
-members = ["tokio-i3ipc"]
-exclude = ["i3ipc-types", "i3-ipc", "async-i3ipc"]
+members = ["tokio-i3ipc", "i3ipc-types", "i3-ipc", "async-i3ipc"]

--- a/i3-ipc/src/lib.rs
+++ b/i3-ipc/src/lib.rs
@@ -58,6 +58,9 @@ pub struct I3;
 #[derive(Debug)]
 pub struct I3Stream(UnixStream);
 
+impl I3IPC for I3Stream {}
+impl I3Protocol for I3Stream {}
+
 /// Provides the `connect` method for `I3`
 impl Connect for I3 {
     type Stream = I3Stream;

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -364,7 +364,6 @@ mod tests {
     fn test_other_tree() {
         let output = include_str!("../test/other_tree.json");
         let o: Result<Node, serde_json::error::Error> = serde_json::from_str(&output);
-        dbg!(&o);
         assert!(o.is_ok());
     }
 


### PR DESCRIPTION
Bring back the workspace, making the trait impls all play nice by monomorphisation to specific types.

I can't see why you'd ever want to use the methods on something that's not a `UnixStream` so I think this should be fine.