### PR TITLE
Update rect fields to handle signed values

### DIFF
--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -204,12 +204,22 @@ pub enum WindowType {
     Unknown,
 }
 
+#[cfg(feature = "sway")]
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Rect {
     pub x: i64,
     pub y: i64,
     pub width: i64,
     pub height: i64,
+}
+
+#[cfg(not(feature = "sway"))]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
+pub struct Rect {
+    pub x: usize,
+    pub y: usize,
+    pub width: usize,
+    pub height: usize,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug, Copy)]

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -206,10 +206,10 @@ pub enum WindowType {
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Rect {
-    pub x: usize,
-    pub y: usize,
-    pub width: usize,
-    pub height: usize,
+    pub x: i64,
+    pub y: i64,
+    pub width: i64,
+    pub height: i64,
 }
 
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug, Copy)]

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -207,10 +207,10 @@ pub enum WindowType {
 #[cfg(feature = "sway")]
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Rect {
-    pub x: i64,
-    pub y: i64,
-    pub width: i64,
-    pub height: i64,
+    pub x: isize,
+    pub y: isize,
+    pub width: isize,
+    pub height: isize,
 }
 
 #[cfg(not(feature = "sway"))]


### PR DESCRIPTION
i3 defines these fields [as `uint32_t`](https://github.com/i3/i3/blob/04c489043c5caf2d4c07f16bf9606de581dc9800/include/data.h#L155-L160); Sway indirectly defines via wlroots them [as (signed) `int`](https://github.com/swaywm/wlroots/blob/87836dcb55e15cd1f19f5549d4fcd666135dba15/include/wlr/types/wlr_box.h#L16-L19). In practice, it's possible to have negative `x` and `y` values if floating nodes are partially offscreen, or with certain combinations of border settings and a fullscreen window.

Rather than using a feature-dependent type here, `i64` should cover all the possibilities here: it's a strict superset of `uint32_t` and either a superset of or the same as `int`, depending on the platform and architecture.