### PR TITLE
add enum ScratchpadState and add it to Node struct

### DIFF
--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -54,6 +54,7 @@ pub struct Node {
     pub output: Option<String>,
     pub orientation: NodeOrientation,
     pub border: NodeBorder,
+    pub scratchpad_state: ScratchpadState,
     pub percent: Option<f64>,
     pub rect: Rect,
     pub window_rect: Rect,
@@ -266,6 +267,14 @@ pub enum NodeOrientation {
     Horizontal,
     Vertical,
     None,
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Debug, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum ScratchpadState {
+    None,
+    Fresh,
+    Changed,
 }
 
 /// Marks Reply


### PR DESCRIPTION
in i3 Node structure there is a variable called scratchpad_state, which is one of three values: NONE, FRESH, or CHANGED. It is useful for figuring out whether a floating window is/was in a scratchpad (so basically whether you need to do "move scratchpad" or if "scratchpad show" will suffice). I can't see anything else that has do be done before a merge, but I'm open to do some more work if need be