### PR TITLE
fixes Rect.x/y for offscreen windows

### DIFF
--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -229,8 +229,8 @@ pub struct Rect {
 #[cfg(not(feature = "sway"))]
 #[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Hash, Debug)]
 pub struct Rect {
-    pub x: usize,
-    pub y: usize,
+    pub x: isize,
+    pub y: isize,
     pub width: usize,
     pub height: usize,
 }


### PR DESCRIPTION
using `usize` caused a bug where `get_tree` would crash when a floating window was placed above or to the left of the screen.