### PR TITLE
Make inner type of Marks and BarIds publicly accessible

### DIFF
--- a/i3ipc-types/src/lib.rs
+++ b/i3ipc-types/src/lib.rs
@@ -32,11 +32,11 @@ pub trait I3Protocol {
         let mut buf = Vec::with_capacity(14);
         buf.extend(<Self as I3Protocol>::MAGIC.as_bytes());
         if let Some(p) = &payload {
-            buf.extend(&(p.as_ref().len() as u32).to_ne_bytes());
+            buf.extend((p.as_ref().len() as u32).to_ne_bytes());
         } else {
-            buf.extend(&(0_u32).to_ne_bytes());
+            buf.extend((0_u32).to_ne_bytes());
         }
-        buf.extend(&<u32 as From<msg::Msg>>::from(msg).to_ne_bytes());
+        buf.extend(<u32 as From<msg::Msg>>::from(msg).to_ne_bytes());
         if let Some(p) = &payload {
             buf.extend(p.as_ref().as_bytes());
         }

--- a/i3ipc-types/src/lib.rs
+++ b/i3ipc-types/src/lib.rs
@@ -74,7 +74,7 @@ pub trait I3IPC: io::Read + io::Write + I3Protocol {
         if &buf[..] != <Self as I3Protocol>::MAGIC.as_bytes() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Expected 'i3-ipc' but received: {:?}", buf),
+                format!("Expected 'i3-ipc' but received: {buf:?}"),
             ));
         }
         // get payload len

--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -287,11 +287,11 @@ pub enum ScratchpadState {
 
 /// Marks Reply
 #[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Debug, Clone)]
-pub struct Marks(Vec<String>);
+pub struct Marks(pub Vec<String>);
 
 /// BarIds
 #[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Debug, Clone)]
-pub struct BarIds(Vec<String>);
+pub struct BarIds(pub Vec<String>);
 
 /// BarConfig Reply
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]


### PR DESCRIPTION
Without marking it `pub`, users can't access the mark values.