### PR TITLE
fix: Enable `ScratchpadState` for sway feature

### DIFF
--- a/i3ipc-types/src/reply.rs
+++ b/i3ipc-types/src/reply.rs
@@ -55,7 +55,6 @@ pub struct Node {
     pub output: Option<String>,
     pub orientation: NodeOrientation,
     pub border: NodeBorder,
-    #[cfg(not(feature = "sway"))]
     pub scratchpad_state: ScratchpadState,
     pub percent: Option<f64>,
     pub rect: Rect,


### PR DESCRIPTION
I'm getting an error deserializing Window events in the current version of sway for Arch.